### PR TITLE
Attempt to fix "uptime" metric missing on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,10 @@ docs/debugging/inspect/inspect
 docs/debugging/pprofgoparser/pprofgoparser
 docs/debugging/reorder-disks/reorder-disks
 docs/debugging/populate-hard-links/populate-hardlinks
+
+minio-service.err.log
+minio-service.exe
+minio-service.out.log
+minio-service.wrapper.log
+minio-service.xml
+minio.exe


### PR DESCRIPTION
This is just an illustration of how to fix such issue. This fix doesn't actually work.
This fix requires a go module that wraps Win32 APIs.
I found one such module initially which is github.com/gonutz/w32/v2, but it doesn't exist any more.
I have yet to find a replacement for it.
Once a proper replacement is found, I need to add one line in go.mod. Add this module as a required one. (indirectly required)
Then I need to add one line in the "import" section of metrics-v2.go.

More specific about the fix, the few modules I found all use a signature for GetProcessTimes very similar to real Win32 API.
The function takes a few FILETIME pointers and the return values are written to the memory pointed by those pointer. But what is the proper data type for FILETIME in go? And how to convert FILETIME to float64 Unix time?
These questions are yet to be answered.
